### PR TITLE
Added support for DJANGO_SITE

### DIFF
--- a/.idea/ruff.xml
+++ b/.idea/ruff.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="RuffConfigService">
     <option name="globalRuffExecutablePath" value="/opt/homebrew/bin/ruff" />
-    <option name="projectRuffExecutablePath" value="$USER_HOME$/Library/Caches/pypoetry/virtualenvs/django-settings-env-VOQU9kUv-py3.12/bin/ruff" />
+    <option name="projectRuffExecutablePath" value="$USER_HOME$/Library/Caches/pypoetry/virtualenvs/dbscripts-WCYxVkYY-py3.12/bin/ruff" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -15,6 +15,16 @@
       </list>
     </option>
   </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\(#(\d+)\)" />
+          <option name="linkRegexp" value="https://github.com/deeprave/dbscripts/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+### 2024.1.0
+- Switched to year-semantic versioning
+- Additional support for environment variables to set the default variable prefix, now supports ENVPREIFX and uppercased DJANGO_SITE (for my own convenience)
+
 ### 1.5.4
 - documentation corrections
 

--- a/dbscripts/dblib.py
+++ b/dbscripts/dblib.py
@@ -23,7 +23,7 @@ class EnvironmentNotConfigured(Exception):
 
 
 env = Env(readenv=True, exception=EnvironmentNotConfigured)
-env_prefix = env("ENVPREFIX", default=None)
+env_prefix = None
 
 
 def set_env_prefix(prefix: str):

--- a/dbscripts/dbready.py
+++ b/dbscripts/dbready.py
@@ -11,7 +11,6 @@ from argparse import ArgumentParser
 
 from psycopg import DatabaseError
 
-from envex import Env
 
 from dbscripts.dblib import pg_connect, pg_database_exists, pg_db_info, set_env_prefix
 
@@ -53,11 +52,7 @@ def main():
 
     a = parser.parse_args()
 
-    env = Env(readenv=True)
-    if not a.prefix:
-        a.prefix = env("ENVPREFIX") or env("DJANGO_SITE").upper() if env.is_set("DJANGO_SITE") else None
-    if a.prefix and a.prefix != "-":
-        set_env_prefix(a.prefix)
+    set_env_prefix(a.prefix)
 
     dbi = pg_db_info(host=a.host, port=a.port, name=a.name, role=a.user, user=a.user, password=a.pswd, url=a.url)
 

--- a/dbscripts/dbready.py
+++ b/dbscripts/dbready.py
@@ -11,6 +11,8 @@ from argparse import ArgumentParser
 
 from psycopg import DatabaseError
 
+from envex import Env
+
 from dbscripts.dblib import pg_connect, pg_database_exists, pg_db_info, set_env_prefix
 
 logging.basicConfig(
@@ -51,7 +53,10 @@ def main():
 
     a = parser.parse_args()
 
-    if a.prefix:
+    env = Env(readenv=True)
+    if not a.prefix:
+        a.prefix = env("ENVPREFIX") or env("DJANGO_SITE").upper() if env.is_set("DJANGO_SITE") else None
+    if a.prefix and a.prefix != "-":
         set_env_prefix(a.prefix)
 
     dbi = pg_db_info(host=a.host, port=a.port, name=a.name, role=a.user, user=a.user, password=a.pswd, url=a.url)

--- a/dbscripts/dbutil.py
+++ b/dbscripts/dbutil.py
@@ -7,7 +7,6 @@ Create/remove/test database for django using best practices.
 import logging
 import textwrap
 
-from envex import Env
 
 from dbscripts.dblib import pg_database_exists, pg_db_info, pg_drop_database, pg_setup, set_env_prefix
 
@@ -51,11 +50,7 @@ def main():
     parser.add_argument("-p", "--pswd", default=None, help="override database password")
     a = parser.parse_args()
 
-    env = Env(readenv=True)
-    if not a.prefix:
-        a.prefix = env("ENVPREFIX") or env("DJANGO_SITE").upper() if env.is_set("DJANGO_SITE") else None
-    if a.prefix and a.prefix != "-":
-        set_env_prefix(a.prefix)
+    set_env_prefix(a.prefix)
 
     dbi = pg_db_info(host=a.host, port=a.port, name=a.name, role=a.role, user=a.user, password=a.pswd, url=a.url)
 

--- a/dbscripts/dbutil.py
+++ b/dbscripts/dbutil.py
@@ -7,6 +7,8 @@ Create/remove/test database for django using best practices.
 import logging
 import textwrap
 
+from envex import Env
+
 from dbscripts.dblib import pg_database_exists, pg_db_info, pg_drop_database, pg_setup, set_env_prefix
 
 logging.basicConfig(
@@ -49,7 +51,10 @@ def main():
     parser.add_argument("-p", "--pswd", default=None, help="override database password")
     a = parser.parse_args()
 
-    if a.prefix:
+    env = Env(readenv=True)
+    if not a.prefix:
+        a.prefix = env("ENVPREFIX") or env("DJANGO_SITE").upper() if env.is_set("DJANGO_SITE") else None
+    if a.prefix and a.prefix != "-":
         set_env_prefix(a.prefix)
 
     dbi = pg_db_info(host=a.host, port=a.port, name=a.name, role=a.role, user=a.user, password=a.pswd, url=a.url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbscripts"
-version = "1.5.3"
+version = "2024.1.0"
 description = "Collection of helper scripts for PostgreSQL"
 authors = ["David Nugent <davidn@uniquode.io>"]
 license = "MIT"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 extend = "./pyproject.toml"
-extend-exclude = [".venv", ".idea", ".vscode", ".*_cache"]
+extend-exclude = [".venv", ".idea", ".vscode", ".*_cache", "migrations"]
 line-length = 120
 indent-width = 4
 fix = true
@@ -9,7 +9,7 @@ output-format = "full"
 target-version = "py310"
 
 [lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F", "Q"]


### PR DESCRIPTION
- Adds support for DJANGO_SITE
- Switch to year based semantic version numbers

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for the DJANGO_SITE environment variable to set the default variable prefix and switches the project to year-based semantic versioning. Additionally, the ruff.toml configuration has been updated to exclude the migrations directory, and the CHANGELOG.md has been updated to document these changes.

- **New Features**:
    - Added support for the DJANGO_SITE environment variable to set the default variable prefix.
- **Enhancements**:
    - Switched to year-based semantic versioning.
- **Build**:
    - Updated ruff.toml to extend exclude migrations directory.
- **Documentation**:
    - Updated CHANGELOG.md to reflect the switch to year-semantic versioning and the addition of DJANGO_SITE support.

<!-- Generated by sourcery-ai[bot]: end summary -->