### PR TITLE
Set logging level to WARN and adjust logging configuration.

### DIFF
--- a/dbscripts/dbready.py
+++ b/dbscripts/dbready.py
@@ -14,8 +14,12 @@ from psycopg import DatabaseError
 
 from dbscripts.dblib import pg_connect, pg_database_exists, pg_db_info, set_env_prefix, set_verbosity
 
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(levelname)-7s %(message)s", handlers=[logging.StreamHandler()]
+    level=logging.WARN,
+    format="%(asctime)s %(levelname)-7s %(message)s",
+    handlers=[logging.StreamHandler()]
 )
 
 
@@ -59,9 +63,6 @@ def main():
 
     db = dbi.copy()
     db.name = ""
-
-    if a.verbose:
-        logging.info(f"DATABASE_URL={dbi.log_url()}")
 
     now = time.time()
     end_at = now

--- a/dbscripts/dbutil.py
+++ b/dbscripts/dbutil.py
@@ -15,8 +15,8 @@ from dbscripts.dblib import pg_database_exists, pg_db_info, pg_drop_database, pg
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
 logging.basicConfig(
+    level=logging.WARN,
     format="%(asctime)s %(levelname)-7s %(message)s",
-    level=logging.DEBUG,
     handlers=[StreamHandler()]
 )
 


### PR DESCRIPTION
Revised logging setup to remove existing handlers and set the default log level to WARN instead of INFO or DEBUG. Also removed a verbose logging statement in `dbready.py` to streamline output.

## Summary by Sourcery

Enhancements:
- Remove existing logging handlers and set up new handler with the WARN logging level.